### PR TITLE
Feature fix include installs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Tests
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Tests
 
 on:
   push:
@@ -14,13 +14,13 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     
     steps:
 # Setup and bootstrap
     - uses: actions/checkout@v1
     - name: Install mpich
-      run: sudo apt-get install libmpich-dev
+      run: sudo apt-get update && sudo apt-get install libmpich-dev
     - name: init submodules
       run: git submodule init
     - name: update submodules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
 # Setup and bootstrap
     - uses: actions/checkout@v1
     - name: Install mpich
-      run: sudo apt-get install libmpich-dev
+      run: sudo apt-get update && sudo apt-get install libmpich-dev
     - name: init submodules
       run: git submodule init
     - name: update submodules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     
     steps:
 # Setup and bootstrap

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Authors:
 Contributors:
   
   David Knapp <davidknapp1@gmx.de>
+  Lukas Dreyer <lukas.dreyer@dlr.de> 

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ echo "| Checking MPI and related programs"
 echo "o---------------------------------------"
 
 dnl A nonempty second/third argument causes to enable F77+F90/CXX, respectively.
-SC_MPI_CONFIG([T8], [yes], [yes])
+SC_MPI_CONFIG([T8], [], [yes])
 SC_MPI_ENGAGE([T8])
 # This is needed for compatibility with automake >= 1.12
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])

--- a/doc/author_dreyer.txt
+++ b/doc/author_dreyer.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Lukas Dreyer (lukas.dreyer@dlr.de)

--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -24,7 +24,6 @@
 #include <sc_statistics.h>
 #include <t8_schemes/t8_default_cxx.hxx>
 #include <t8_forest.h>
-#include <t8_forest/t8_forest_private.h>        /* TODO: remove */
 #include <t8_forest/t8_forest_iterate.h>
 #include <t8_forest/t8_forest_partition.h>
 #include <t8_forest_vtk.h>

--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -25,7 +25,6 @@
 #include <t8_schemes/t8_default_cxx.hxx>
 #include <t8_forest.h>
 #include <t8_forest/t8_forest_private.h>        /* TODO: remove */
-#include <t8_forest/t8_forest_ghost.h>
 #include <t8_forest/t8_forest_iterate.h>
 #include <t8_forest/t8_forest_partition.h>
 #include <t8_forest_vtk.h>

--- a/scripts/t8indent
+++ b/scripts/t8indent
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# This is the GNU style for indent 2.2.9 (according to man page)
+#
+#"$INDENT" \
+#    -nbad -bap -nbc -bbo -bl -bli2 -bls -ncdb -nce -cp1 -cs -di2 \
+#    -ndj -nfc1 -nfca -hnl -i2 -ip5 -lp -pcs -nprs -psl -saf -sai \
+#    -saw -nsc -nsob
+#    "$@"
+
+# This is our modification
+#
+# blank line after procedure body
+# braces indent 0 (or do you want -bl2 here and -bl below?)
+# braces to right of control statements (or do you want -bl here?)
+# no tabs
+# put the return type of a function on a separate line
+# swallow optional blank lines
+INDENT_OPTIONS="-bap -bli0 -br -nut -psl -sob -di20"
+
+INDENT=`which gnuindent 2> /dev/null`
+if test -z "$INDENT" ; then
+	INDENT=`which gindent`
+fi
+if test -z "$INDENT" ; then
+	INDENT=`which indent`
+fi
+
+for arg in "$@" ; do
+  if [ "x$arg" == "x-o" ]; then
+    WANTSOUT=1
+  fi
+done
+if [ -z "$WANTSOUT" ]; then
+  for NAME in "$@" ; do
+    $INDENT $INDENT_OPTIONS "$NAME"
+  done
+else
+  $INDENT $INDENT_OPTIONS $@
+fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,14 +14,14 @@ libt8_installed_headers = \
   src/t8_forest.h \
   src/t8_forest/t8_forest_adapt.h src/t8_forest_vtk.h \
   src/t8_geometry.h \
-  src/t8_vec.h 
+  src/t8_vec.h src/t8_forest/t8_forest_private.h src/t8_vtk.h
 libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_stash.h src/t8_cmesh/t8_cmesh_trees.h \
   src/t8_cmesh/t8_cmesh_types.h src/t8_cmesh/t8_cmesh_partition.h \
   src/t8_cmesh/t8_cmesh_refine.h src/t8_cmesh/t8_cmesh_copy.h \
   src/t8_cmesh/t8_cmesh_offset.h src/t8_forest/t8_forest_partition.h \
-  src/t8_forest/t8_forest_cxx.h src/t8_forest/t8_forest_private.h \
-  src/t8_forest/t8_forest_ghost.h src/t8_forest/t8_forest_iterate.h src/t8_vtk.h \
+  src/t8_forest/t8_forest_cxx.h  \
+  src/t8_forest/t8_forest_ghost.h src/t8_forest/t8_forest_iterate.h \
 	src/t8_forest/t8_forest_balance.h src/t8_forest/t8_forest_types.h 
 libt8_compiled_sources = \
   src/t8.c src/t8_eclass.c src/t8_mesh.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ libt8_installed_headers = \
   src/t8_forest.h \
   src/t8_forest/t8_forest_adapt.h src/t8_forest_vtk.h \
   src/t8_geometry.h \
-  src/t8_vec.h src/t8_forest/t8_forest_private.h src/t8_vtk.h
+  src/t8_vec.h src/t8_vtk.h
 libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_stash.h src/t8_cmesh/t8_cmesh_trees.h \
   src/t8_cmesh/t8_cmesh_types.h src/t8_cmesh/t8_cmesh_partition.h \
@@ -22,7 +22,8 @@ libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_offset.h src/t8_forest/t8_forest_partition.h \
   src/t8_forest/t8_forest_cxx.h  \
   src/t8_forest/t8_forest_ghost.h src/t8_forest/t8_forest_iterate.h \
-	src/t8_forest/t8_forest_balance.h src/t8_forest/t8_forest_types.h 
+  src/t8_forest/t8_forest_balance.h src/t8_forest/t8_forest_types.h \
+  src/t8_forest/t8_forest_private.h 
 libt8_compiled_sources = \
   src/t8.c src/t8_eclass.c src/t8_mesh.c \
   src/t8_element.c src/t8_element_cxx.cxx \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,8 @@ libt8_installed_headers = \
   src/t8_cmesh/t8_cmesh_save.h \
   src/t8_forest.h \
   src/t8_forest/t8_forest_adapt.h src/t8_forest_vtk.h \
-  src/t8_geometry.h
+  src/t8_geometry.h \
+  src/t8_vec.h 
 libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_stash.h src/t8_cmesh/t8_cmesh_trees.h \
   src/t8_cmesh/t8_cmesh_types.h src/t8_cmesh/t8_cmesh_partition.h \
@@ -21,7 +22,7 @@ libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_offset.h src/t8_forest/t8_forest_partition.h \
   src/t8_forest/t8_forest_cxx.h src/t8_forest/t8_forest_private.h \
   src/t8_forest/t8_forest_ghost.h src/t8_forest/t8_forest_iterate.h src/t8_vtk.h \
-	src/t8_forest/t8_forest_balance.h src/t8_vec.h src/t8_forest/t8_forest_types.h 
+	src/t8_forest/t8_forest_balance.h src/t8_forest/t8_forest_types.h 
 libt8_compiled_sources = \
   src/t8.c src/t8_eclass.c src/t8_mesh.c \
   src/t8_element.c src/t8_element_cxx.cxx \

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -429,6 +429,42 @@ t8_locidx_t         t8_forest_cmesh_ltreeid_to_ltreeid (t8_forest_t forest,
 t8_ctree_t          t8_forest_get_coarse_tree (t8_forest_t forest,
                                                t8_locidx_t ltreeid);
 
+/** Compute the leaf face neighbors of a forest.
+ * \param [in]    forest  The forest. Must have a valid ghost layer.
+ * \param [in]    ltreeid A local tree id.
+ * \param [in]    leaf    A leaf in tree \a ltreeid of \a forest.
+ * \param [out]   neighbor_leafs Unallocated on input. On output the neighbor
+ *                        leafs are stored here.
+ * \param [in]    face    The index of the face across which the face neighbors
+ *                        are searched.
+ * \param [out]   dual_face On output the face id's of the neighboring elements' faces.
+ * \param [out]   num_neighbors On output the number of neighbor leafs.
+ * \param [out]   pelement_indices Unallocated on input. On output the element indices
+ *                        of the neighbor leafs are stored here.
+ *                        0, 1, ... num_local_el - 1 for local leafs and
+ *                        num_local_el , ... , num_local_el + num_ghosts - 1 for ghosts.
+ * \param [out]   pneigh_scheme On output the eclass scheme of the neighbor elements.
+ * \param [in]    forest_is_balanced True if we know that \a forest is balanced, false
+ *                        otherwise.
+ * \note If there are no face neighbors, then *neighbor_leafs = NULL, num_neighbors = 0,
+ * and *pelement_indices = NULL on output.
+ * \note Currently \a forest must be balanced.
+ * \note \a forest must be committed before calling this function.
+ */
+void                t8_forest_leaf_face_neighbors (t8_forest_t forest,
+                                                   t8_locidx_t ltreeid,
+                                                   const t8_element_t * leaf,
+                                                   t8_element_t **
+                                                   pneighbor_leafs[],
+                                                   int face,
+                                                   int *dual_faces[],
+                                                   int *num_neighbors,
+                                                   t8_locidx_t **
+                                                   pelement_indices,
+                                                   t8_eclass_scheme_c **
+                                                   pneigh_scheme,
+                                                   int forest_is_balanced);
+
 /** Exchange ghost information of user defined element data.
  * \param[in] forest       The forest. Must be committed.
  * \param[in] element_data An array of length num_local_elements + num_ghosts

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -429,6 +429,22 @@ t8_locidx_t         t8_forest_cmesh_ltreeid_to_ltreeid (t8_forest_t forest,
 t8_ctree_t          t8_forest_get_coarse_tree (t8_forest_t forest,
                                                t8_locidx_t ltreeid);
 
+/** Exchange ghost information of user defined element data.
+ * \param[in] forest       The forest. Must be committed.
+ * \param[in] element_data An array of length num_local_elements + num_ghosts
+ *                         storing one value for each local element and ghost in \a forest.
+ *                         After calling this function the entries for the ghost elements
+ *                         are update with the entries in the \a element_data array of
+ *                         the corresponding owning process.
+ * \note This function is collective and hence must be called by all processes in the forest's
+ *       MPI Communicator.
+ */
+/* TODO: In \ref t8_forest_ghost_cxx we already implemented a begin and end function
+ *       that allow for overlapping communication and computation. We will make them
+ *       available in this interface in the future. */
+void                t8_forest_ghost_exchange_data (t8_forest_t forest,
+                                                   sc_array_t * element_data);
+
 /** Enable or disable profiling for a forest. If profiling is enabled, runtimes
  * and statistics are collected during forest_commit.
  * \param [in,out] forest        The forest to be updated.

--- a/src/t8_forest/t8_forest_ghost.h
+++ b/src/t8_forest/t8_forest_ghost.h
@@ -130,13 +130,6 @@ t8_locidx_t         t8_forest_ghost_remote_first_tree (t8_forest_t forest,
 t8_locidx_t         t8_forest_ghost_remote_first_elem (t8_forest_t forest,
                                                        int remote);
 
-/* TODO: - document
- *       - make accesible to forest API
- *       - make a begin and end version
- */
-void                t8_forest_ghost_exchange_data (t8_forest_t forest,
-                                                   sc_array_t * element_data);
-
 /** Increase the reference count of a ghost structure.
  * \param [in,out]  ghost     On input, this ghost structure must exist with
  *                            positive reference count.

--- a/src/t8_forest/t8_forest_private.h
+++ b/src/t8_forest/t8_forest_private.h
@@ -408,42 +408,6 @@ t8_gloidx_t         t8_forest_element_half_face_neighbors (t8_forest_t forest,
                                                            int num_neighs,
                                                            int dual_faces[]);
 
-/** Compute the leaf face neighbors of a forest.
- * \param [in]    forest  The forest. Must have a valid ghost layer.
- * \param [in]    ltreeid A local tree id.
- * \param [in]    leaf    A leaf in tree \a ltreeid of \a forest.
- * \param [out]   neighbor_leafs Unallocated on input. On output the neighbor
- *                        leafs are stored here.
- * \param [in]    face    The index of the face across which the face neighbors
- *                        are searched.
- * \param [out]   dual_face On output the face id's of the neighboring elements' faces.
- * \param [out]   num_neighbors On output the number of neighbor leafs.
- * \param [out]   pelement_indices Unallocated on input. On output the element indices
- *                        of the neighbor leafs are stored here.
- *                        0, 1, ... num_local_el - 1 for local leafs and
- *                        num_local_el , ... , num_local_el + num_ghosts - 1 for ghosts.
- * \param [out]   pneigh_scheme On output the eclass scheme of the neighbor elements.
- * \param [in]    forest_is_balanced True if we know that \a forest is balanced, false
- *                        otherwise.
- * \note If there are no face neighbors, then *neighbor_leafs = NULL, num_neighbors = 0,
- * and *pelement_indices = NULL on output.
- * \note Currently \a forest must be balanced.
- * \note \a forest must be committed before calling this function.
- */
-void                t8_forest_leaf_face_neighbors (t8_forest_t forest,
-                                                   t8_locidx_t ltreeid,
-                                                   const t8_element_t * leaf,
-                                                   t8_element_t **
-                                                   pneighbor_leafs[],
-                                                   int face,
-                                                   int *dual_faces[],
-                                                   int *num_neighbors,
-                                                   t8_locidx_t **
-                                                   pelement_indices,
-                                                   t8_eclass_scheme_c **
-                                                   pneigh_scheme,
-                                                   int forest_is_balanced);
-
 /** Iterate over all leafs of a forest and for each face compute the face neighbor
  * leafs with \ref t8_forest_leaf_face_neighbors and print their local element ids.
  * This function is meant for debugging only.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,7 +15,8 @@ t8code_test_programs = \
 	test/t8_test_transform \
 	test/t8_test_half_neighbors \
   test/t8_test_element_count_leafs \
-  test/t8_test_search
+  test/t8_test_search \
+    test/t8_test_find_parent
 
 test_t8_test_eclass_SOURCES = test/t8_test_eclass.c
 test_t8_test_bcast_SOURCES = test/t8_test_bcast.c
@@ -30,6 +31,7 @@ test_t8_test_transform_SOURCES = test/t8_test_transform.cxx
 test_t8_test_half_neighbors_SOURCES = test/t8_test_half_neighbors.cxx
 test_t8_test_element_count_leafs_SOURCES = test/t8_test_element_count_leafs.cxx
 test_t8_test_search_SOURCES = test/t8_test_search.cxx
+test_t8_test_find_parent_SOURCES = test/t8_test_find_parent.cpp
 
 TESTS += $(t8code_test_programs)
 check_PROGRAMS += $(t8code_test_programs)

--- a/test/t8_test_find_parent.cpp
+++ b/test/t8_test_find_parent.cpp
@@ -99,7 +99,7 @@ main (int argc, char **argv)
 #ifdef T8_ENABLE_DEBUG
   const int maxlvl = 8;
 #else
-  const int maxlvl = 10;
+  const int maxlvl = 9;
 #endif
 
 

--- a/test/t8_test_find_parent.cpp
+++ b/test/t8_test_find_parent.cpp
@@ -1,0 +1,120 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default_cxx.hxx>
+
+
+/* Build every child for the parent element and check wether the computed parent is
+ * again the input element. Then call this function for every child, until maxlevel is
+ * reached.
+ */
+static void
+t8_recursive_child_find_parent (t8_element_t * element, t8_element_t * child,
+                                t8_element_t * test_parent, t8_eclass_scheme_c * ts,
+                                int level, const int maxlvl)
+{
+  T8_ASSERT (level <= maxlvl &&
+             maxlvl <= ts->t8_element_maxlevel() - 1);
+  int                 num_children, i;
+  /* Get number of children */
+  num_children = ts->t8_element_num_children (element);
+  /* Get child and test_parent, to check if test_parent = parent of child */
+  if (level == maxlvl)
+    return;
+  for (i = 0; i < num_children; i++) {
+    /* Compute child i */
+    ts->t8_element_child (element, i, child);
+    /* Compute parent of child */
+    ts->t8_element_parent (child, test_parent);
+    /* If its equal, call child_find_parent, to check if parent-child relation
+     * is correct in next level until maxlvl is reached*/
+    SC_CHECK_ABORT (!ts->t8_element_compare (element, test_parent),
+                    "Computed child_parent is not the parent");
+
+    t8_recursive_child_find_parent (child, element, test_parent, ts, level + 1,
+                                    maxlvl);
+    /* After the check we know the parent-function is correct for this child.
+     * Therefore we can use it to recompute the element*/
+    ts->t8_element_parent(child, element);
+  }
+}
+
+static void
+t8_compute_child_find_parent (const int maxlvl)
+{
+  t8_element_t       *element, *child, *test_parent;
+  t8_scheme_cxx      *scheme;
+  t8_eclass_scheme_c *ts;
+  int                 eclassi;
+  t8_eclass_t         eclass;
+  scheme = t8_scheme_new_default_cxx ();
+  for (eclassi = T8_ECLASS_ZERO; eclassi < T8_ECLASS_PYRAMID; eclassi++) {
+    /* TODO: Include pyramids as soon as they are supported. */
+    eclass = (t8_eclass_t) eclassi;
+    /* Get scheme for eclass */
+    ts = scheme->eclass_schemes[eclass];
+    /* Get element and initialize it */
+    ts->t8_element_new (1, &element);
+    ts->t8_element_new (1, &child);
+    ts->t8_element_new (1, &test_parent);
+
+    ts->t8_element_set_linear_id (element, 0, 0);
+    /* Check for correct parent-child relation */
+    t8_recursive_child_find_parent (element, child, test_parent, ts, 0, maxlvl);
+    /* Destroy element */
+    ts->t8_element_destroy (1, &element);
+    ts->t8_element_destroy(1, &child);
+    ts->t8_element_destroy(1, &test_parent);
+
+  }
+  /* Destroy scheme */
+  t8_scheme_cxx_unref (&scheme);
+}
+
+int
+main (int argc, char **argv)
+{
+  int     mpiret;
+#ifdef T8_ENABLE_DEBUG
+  const int maxlvl = 8;
+#else
+  const int maxlvl = 9;
+#endif
+
+
+  mpiret = sc_MPI_Init(&argc, &argv);
+  SC_CHECK_MPI(mpiret);
+  sc_init(sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
+  p4est_init(NULL, SC_LP_ESSENTIAL);
+  t8_init(SC_LP_DEFAULT);
+
+  t8_compute_child_find_parent (maxlvl);
+
+
+  sc_finalize();
+
+  mpiret = sc_MPI_Finalize();
+  SC_CHECK_MPI(mpiret);
+  return 0;
+}

--- a/test/t8_test_find_parent.cpp
+++ b/test/t8_test_find_parent.cpp
@@ -1,0 +1,96 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default_cxx.hxx>
+
+
+/* Build every child for the parent element and check wether the computed parent is
+ * again the input element. Then call this function for every child, until maxlevel is
+ * reached.
+ */
+static void
+t8_recursive_child_find_parent (t8_element_t * element,
+                                t8_eclass_scheme_c * ts, int level,
+                                int maxlvl)
+{
+  T8_ASSERT (level <= maxlvl
+             || maxlvl < ts->t8_element_num_children (element));
+  int                 num_children, i;
+  t8_element_t       *child, *test_parent;
+  /*Get number of children */
+  num_children = ts->t8_element_num_children (element);
+  /*Get child and test_parent, to check if test_parent = parent of child */
+  ts->t8_element_new (1, &child);
+  ts->t8_element_new (1, &test_parent);
+  if (level == maxlvl)
+    return;
+  for (i = 0; i < num_children; i++) {
+    /*Compute child i */
+    ts->t8_element_child (element, i, child);
+    /*Compute parent of child */
+    ts->t8_element_parent (child, test_parent);
+    /*If its equal, call child_find_parent, to check if parent-child relation
+     * is correct in next level until maxlvl is reached*/
+    if (ts->t8_element_compare (element, test_parent)) {
+      SC_ABORT ("Computed child_parent is not the parent");
+    }
+    else {
+      t8_recursive_child_find_parent (child, ts, level + 1, maxlvl);
+    }
+  }
+}
+
+static void
+t8_compute_child_find_parent (int maxlvl)
+{
+  t8_element_t       *element;
+  t8_scheme_cxx      *scheme;
+  t8_eclass_scheme_c *ts;
+  int                 eclassi;
+  t8_eclass_t         eclass;
+  scheme = t8_scheme_new_default_cxx ();
+  for (eclassi = T8_ECLASS_ZERO; eclassi < T8_ECLASS_PYRAMID; eclassi++) {
+    eclass = (t8_eclass_t) eclassi;
+    /*Get scheme for eclass */
+    ts = scheme->eclass_schemes[eclass];
+    /*Get element and initialize it */
+    ts->t8_element_new (1, &element);
+    ts->t8_element_set_linear_id (element, 0, 0);
+    /*Check for correct parent-child relation */
+    t8_recursive_child_find_parent (element, ts, 0, maxlvl);
+    printf ("%s: Success\n", t8_eclass_to_string[eclass]);
+    /*Destroy element */
+    ts->t8_element_destroy (1, &element);
+
+  }
+  /*Destroy scheme */
+  t8_scheme_cxx_unref (&scheme);
+}
+
+int
+main ()
+{
+  t8_compute_child_find_parent (4);
+  return 0;
+}

--- a/test/t8_test_find_parent.cpp
+++ b/test/t8_test_find_parent.cpp
@@ -37,28 +37,27 @@ t8_recursive_child_find_parent (t8_element_t * element, t8_element_t * child,
   T8_ASSERT (level <= maxlvl &&
              maxlvl <= ts->t8_element_maxlevel() - 1);
   int                 num_children, i;
-  t8_element_t       *parent;
   /* Get number of children */
   num_children = ts->t8_element_num_children (element);
   /* Get child and test_parent, to check if test_parent = parent of child */
-  ts->t8_element_new (1, &parent);
-  ts->t8_element_copy(element, parent);
   if (level == maxlvl)
     return;
   for (i = 0; i < num_children; i++) {
     /* Compute child i */
-    ts->t8_element_child (parent, i, child);
+    ts->t8_element_child (element, i, child);
     /* Compute parent of child */
     ts->t8_element_parent (child, test_parent);
     /* If its equal, call child_find_parent, to check if parent-child relation
      * is correct in next level until maxlvl is reached*/
-    SC_CHECK_ABORT (!ts->t8_element_compare (parent, test_parent),
+    SC_CHECK_ABORT (!ts->t8_element_compare (element, test_parent),
                     "Computed child_parent is not the parent");
 
     t8_recursive_child_find_parent (child, element, test_parent, ts, level + 1,
                                     maxlvl);
+    /* After the check we know the parent-function is correct for this child.
+     * Therefore we can use it to recompute the element*/
+    ts->t8_element_parent(child, element);
   }
-  ts->t8_element_destroy(1, &parent);
 }
 
 static void
@@ -100,7 +99,7 @@ main (int argc, char **argv)
 #ifdef T8_ENABLE_DEBUG
   const int maxlvl = 8;
 #else
-  const int maxlvl = 12;
+  const int maxlvl = 10;
 #endif
 
 
@@ -111,6 +110,7 @@ main (int argc, char **argv)
   t8_init(SC_LP_DEFAULT);
 
   t8_compute_child_find_parent (maxlvl);
+
 
   sc_finalize();
 

--- a/test/t8_test_find_parent.cpp
+++ b/test/t8_test_find_parent.cpp
@@ -32,7 +32,7 @@
 static void
 t8_recursive_child_find_parent (t8_element_t * element, t8_element_t * child,
                                 t8_element_t * test_parent, t8_eclass_scheme_c * ts,
-                                int level, int maxlvl)
+                                int level, const int maxlvl)
 {
   T8_ASSERT (level <= maxlvl &&
              maxlvl <= ts->t8_element_maxlevel() - 1);
@@ -62,7 +62,7 @@ t8_recursive_child_find_parent (t8_element_t * element, t8_element_t * child,
 }
 
 static void
-t8_compute_child_find_parent (int maxlvl)
+t8_compute_child_find_parent (const int maxlvl)
 {
   t8_element_t       *element, *child, *test_parent;
   t8_scheme_cxx      *scheme;
@@ -97,6 +97,12 @@ int
 main (int argc, char **argv)
 {
   int     mpiret;
+#ifdef T8_ENABLE_DEBUG
+  const int maxlvl = 8;
+#else
+  const int maxlvl = 12;
+#endif
+
 
   mpiret = sc_MPI_Init(&argc, &argv);
   SC_CHECK_MPI(mpiret);
@@ -104,7 +110,7 @@ main (int argc, char **argv)
   p4est_init(NULL, SC_LP_ESSENTIAL);
   t8_init(SC_LP_DEFAULT);
 
-  t8_compute_child_find_parent (4);
+  t8_compute_child_find_parent (maxlvl);
 
   sc_finalize();
 


### PR DESCRIPTION
Merged recent develop.

Moved t8_forest_exchange_ghost_data to t8_forest.h
Moved t8_forest_leaf_face_neighbors to t8_forest.h
Removed t8_forest_ghost.h and t8_forest_private.h from the installed headers.

You should now be able to build your code without these two headers.